### PR TITLE
Change this.data into this.info

### DIFF
--- a/localtransport.js
+++ b/localtransport.js
@@ -167,7 +167,7 @@ Module.register('localtransport', {
     if (notification === 'LOCAL_TRANSPORT_RESPONSE' && payload.id === this.identifier) {
         Log.info('received' + notification);
         if(payload.data && payload.data.status === "OK"){
-            this.data = payload.data;
+            this.info = payload.data;
             this.loaded = true;
             this.updateDom(this.config.animationSpeed * 1000);
         }
@@ -201,12 +201,12 @@ Module.register('localtransport', {
         var ul = document.createElement("ul");
         var Nrs = 0; //number of routes
         var routeArray = []; //array of all alternatives for later sorting
-        for(var routeKey in this.data.routes) {
+        for(var routeKey in this.info.routes) {
             /*each route describes a way to get from A to Z*/
             //if(Nrs >= this.config.maxAlternatives){
             //  break;
             //}
-            var route = this.data.routes[routeKey];
+            var route = this.info.routes[routeKey];
             var li = document.createElement("li");
             li.className = "small";
             var arrival = 0;


### PR DESCRIPTION
this.data is already used to store information about the module by the magicmirror framework itself. By setting your own data in there it really screws up functionality and compatability with other modules. A rename of data into info will solve this.