### PR TITLE
Added showColor option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Add module configuration to config.js.
 |`maxModuleWidth`|Maximum width of the module in pixel. Unlimited when set to `0`. This option can be used to make the module shorter in case of very long lines for directions. <br><br>**Default value:** `0`|
 |`fade`|Boolean if a fade should be applied - same as for calendar module<br><br>**Default value:** `true`|
 |`fadePoint`|Percentage, where the fade should start. This should be a value between 0 and 1 - same as for calendar module<br><br>**Default value:** `0.1`|
+|`showColor`|Boolean if transport symbols should be displayed in color (Note: symbols for default transport modes are always in grey)<br><br>**Default value:** `true`|
 |`language`|Language to display information in - german `de` or english `en`<br><br>**Default value** `is same as defined in the main config file`|
 |`units`|Units to use - `metric` or `imperial`<br><br>**Default value** `is same as defined in the main config file`|
 |`timeFormat`|`24` or `12` hour clock for displaying the arrival time<br><br>**Default value** `is same as defined in the main config file`|

--- a/localtransport.css
+++ b/localtransport.css
@@ -20,5 +20,8 @@
 .localtransport ul li div {
   margin-left: .5em;
 }
+.localtransport img.symbol.bw {
+  -webkit-filter: grayscale(100%);
+}
 
 /* This beautiful CSS-File has been crafted with LESS (lesscss.org) and compiled by simpLESS (wearekiss.com/simpless) */

--- a/localtransport.js
+++ b/localtransport.js
@@ -15,6 +15,7 @@ Module.register('localtransport', {
     maxWalkTime: 10,
     fade: true,
     fadePoint: 0.1,
+    showColor: true,
     maxModuleWidth: 0,
     animationSpeed: 1,
     updateInterval: 5,
@@ -113,7 +114,11 @@ Module.register('localtransport', {
             /*if walking and walking times should be 
              *specified, add symbol and time*/
             var img = document.createElement("img");
-            img.className = "symbol";
+            if(this.config.showColor){
+                img.className = "symbol";
+            }else{
+                img.className = "symbol bw";
+            }
             img.src = "http://maps.gstatic.com/mapfiles/transit/iw2/6/walk.png";
             //img.src = "/localtransport/walk.png"; //needs to be saved in localtransport/public/walk.png
             wrapper.appendChild(img)
@@ -136,7 +141,11 @@ Module.register('localtransport', {
         if(details) {
             /*add symbol of transport vehicle*/
             var img = document.createElement("img");
-            img.className = "symbol";
+            if(this.config.showColor){
+                img.className = "symbol";
+            }else{
+                img.className = "symbol bw";
+            }
             /* get symbol online*/
             img.src = details.line.vehicle.local_icon || ("http:" + details.line.vehicle.icon);
             /* can provide own symbols under /localtransport/public/*.png */


### PR DESCRIPTION
Added showColor option which can be set to false to force all symbols to be displayed in grayscale as requested in #13 
Note: untested (eventhough I copy pasted from one of my other modules, I might have made a mistake somewhere..)